### PR TITLE
adds python 3.7 compatibility

### DIFF
--- a/octoprint_stats/__init__.py
+++ b/octoprint_stats/__init__.py
@@ -1019,6 +1019,7 @@ class StatsPlugin(octoprint.plugin.EventHandlerPlugin,
 # can be overwritten via __plugin_xyz__ control properties. See the documentation for that.
 __plugin_name__ = "Printer Stats"
 __plugin_version__ = "2.0.2"
+__plugin_pythoncompat__ = ">=2.7,<4"
 __plugin_description__ = "Statistics of your 3D Printer"
 
 def __plugin_load__():

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ plugin_url = "https://github.com/amsbr/OctoPrint-Stats"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ["tinydb", "pandas"]
+plugin_requires = ["tinydb", "pandas", "numpy"]
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
Origin PR from: https://github.com/amsbr/OctoPrint-Stats/pull/37

On my setup Numpy required:
```apt install libatlas-base-dev```