### PR TITLE
Stop double counting cancelled prints and move database location

### DIFF
--- a/octoprint_stats/__init__.py
+++ b/octoprint_stats/__init__.py
@@ -905,7 +905,7 @@ class StatsPlugin(octoprint.plugin.EventHandlerPlugin,
             eventData = {'event_type': 'PRINT_DONE', 
                          'data': {'event_time': datetime.datetime.today().__str__(), 'file': file, 'ptime': ptime, 'origin': origin, 'bed_actual': bed_actual, 'tool0_actual': tool0_actual, 'tool1_actual': tool1_actual, 'tool2_actual': tool2_actual, 'tool0_volume': tool0_volume, 'tool1_volume': tool1_volume, 'tool2_volume': tool2_volume, 'tool0_length': tool0_length, 'tool1_length': tool1_length, 'tool2_length': tool2_length, 'name': name, 'size': size, 'owner': owner}}
 
-        if event == octoprint.events.Events.PRINT_FAILED:
+        if event == octoprint.events.Events.PRINT_FAILED and payload["reason"] == "error":
             if payload["path"] != None:
                 file = payload["path"]
             elif payload["file"] != None:

--- a/octoprint_stats/__init__.py
+++ b/octoprint_stats/__init__.py
@@ -20,10 +20,13 @@ import pandas as pd
 class StatsDB:
     def __init__(self, plugin):
         self.DB_NAME_V1 = plugin._settings.global_get_basefolder("logs") + "/octoprint_stats.db"
-        self.DB_NAME = plugin._settings.global_get_basefolder("logs") + "/octoprint_stats.json"
+        self.DB_NAME_V2 = plugin._settings.global_get_basefolder("logs") + "/octoprint_stats.json"
+        self.DB_NAME = plugin._settings.global_get_basefolder("data") + "/octoprint_stats.json"
         
         if os.path.exists(self.DB_NAME_V1) == True:
             self.migrate_v1()
+        if os.path.exists(self.DB_NAME_V2) == True:
+            os.rename(self.DB_NAME_V2, self.DB_NAME)
         
     def migrate_v1(self):
         conn = sqlite3.connect(self.DB_NAME_V1)

--- a/octoprint_stats/static/js/stats.js
+++ b/octoprint_stats/static/js/stats.js
@@ -68,7 +68,7 @@ $(function () {
 
         fillColor['ERROR'] = 'rgba(241,196,15,0.5)';
         label['ERROR'] = 'Error';
-        stack['ERROR'] = 'Print';
+        stack['ERROR'] = 'Conn';
 
         fillColor['kwh'] = 'rgba(241,196,15,0.5)';
         label['kwh'] = 'kWh';


### PR DESCRIPTION
I'm still getting used to GitHub, I didn't realise a pull request would keep updating with changes to the branch until approved, so creating a new pull request hahaha

When a print is cancelled, in stats this is counted as both "Cancelled" and "Failed". It should be one or the other really. Personally, in my fork, I chose to save the "Failed" status for prints that stopped because of errors. I then moved the "Error" category to the connection stack as this included errors that didn't also stop a print. This way the "Complete" + "Cancelled" + "Failed" is the same height as started.

Additionally, moved the database location to the data folder so that its included in backups.

Tested on Python3, OctoPrint 14.2