### PR TITLE
Add python_requires to prevent people installing on Py2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ plugin_ignored_packages = []
 # Example:
 #     plugin_requires = ["someDependency==dev"]
 #     additional_setup_parameters = {"dependency_links": ["https://github.com/someUser/someRepo/archive/master.zip#egg=someDependency-dev"]}
-additional_setup_parameters = {}
+additional_setup_parameters = {"python_requires": ">=3.5,<4"}
 
 ########################################################################################################################
 


### PR DESCRIPTION
When people spot a plugin they like, they go to the plugin manager to install it.
But it doesn't show up on Py2 installs now due to the compatibility string. So they install it manually.

This saves you from the headaches of 'Installed but not loading' since it refuses, with an error about Python compatibility.