### PR TITLE
Resolve errors when "owner" or "user" are not defined in event playload

### DIFF
--- a/octoprint_stats/__init__.py
+++ b/octoprint_stats/__init__.py
@@ -797,6 +797,11 @@ class StatsPlugin(octoprint.plugin.EventHandlerPlugin,
         # prevent run of not fully started plugin
         if not hasattr(self, 'statDB'):
             return
+        
+        if "owner" not in payload:
+            payload["owner"] = "N/A"
+        if "user" not in payload:
+            payload["user"] = "N/A"
 
         eventData = None
         if event == octoprint.events.Events.CONNECTED:


### PR DESCRIPTION
This patch should fix https://github.com/AlexVerrico/octoprint-stats/issues/32 as well as the issues that I'm running into when using the Continuous Print plugin

```
Traceback (most recent call last):
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/plugin/__init__.py", line 273, in call_plugin
    result = getattr(plugin, method)(*args, **kwargs)
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/util/__init__.py", line 1688, in wrapper
    return f(*args, **kwargs)
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_stats/__init__.py", line 834, in on_event
    owner = payload["owner"]
KeyError: 'owner'
```