### PR TITLE
Added All Time Filter for Printer Statistics

### DIFF
--- a/octoprint_stats/__init__.py
+++ b/octoprint_stats/__init__.py
@@ -450,6 +450,8 @@ class StatsPlugin(octoprint.plugin.EventHandlerPlugin,
                                     (event_df.event_y == str(datetime.datetime.today().year - 4)) |
                                     (event_df.event_y == str(datetime.datetime.today().year - 5)) |
                                     (event_df.event_y == str(datetime.datetime.today().year - 6))]
+            elif filterp == 'all_time':
+                event_df = event_df
             elif filterp == 'today':
                 event_df = event_df[(event_df.event_ymd == datetime.datetime.today().strftime("%Y-%m-%d"))]
 

--- a/octoprint_stats/templates/stats_tab.jinja2
+++ b/octoprint_stats/templates/stats_tab.jinja2
@@ -11,6 +11,7 @@
         <option value="last_year">Last Year</option>
         <option value="last3_year">Last 3 Years</option>
         <option value="last6_year">Last 6 Years</option>
+        <option value="all_time">All Time</option>
       </select>
     </td>
     <td style="vertical-align:top;">


### PR DESCRIPTION
Easily display the entire history without switching between `Current Year` and `Last X Years` as `Last X Years` does not include the current year in its statistics. 

For comparison `All Time` vs `Last 6 Years`:

![All](https://user-images.githubusercontent.com/53194670/226182453-2c9ad341-27ac-454e-a513-5595dec12df7.png)
![Last X](https://user-images.githubusercontent.com/53194670/226182455-88424e34-037d-45ec-b80d-0f385f681e27.png)

_Tested with OctoPrint 1.8.7 - OctoPi 1.0.0 - Python 3.9.2_