### PR TITLE
Swap libatlas-base-dev for libopenblas-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 This plugin is designed to show statistics of your printer and estimate power usage in kWh.
 
 ## Setup
-#### Important! You may need to install the system package libopenblas-dev for this plugin to work by running `sudo apt-get install libopenblas-dev`.
+
+**Important! You may need to install the system package libatlas-base-dev for this plugin to work by running `sudo apt install libatlas-base-dev`.  
+Some users have also reported that instead of libatlas-base-dev, they needed to install the system package libopenblas-dev by running `sudo apt-get install libopenblas-dev`.**
+
 ### Python 3:
 Install via the bundled [Plugin Manager](https://github.com/foosel/OctoPrint/wiki/Plugin:-Plugin-Manager)
 or manually using this URL:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This plugin is designed to show statistics of your printer and estimate power usage in kWh.
 
 ## Setup
-#### Important! You may need to install the system package libatlas-base-dev for this plugin to work by running `sudo apt install libatlas-base-dev`.
+#### Important! You may need to install the system package libopenblas-dev for this plugin to work by running `sudo apt-get install libopenblas-dev`.
 ### Python 3:
 Install via the bundled [Plugin Manager](https://github.com/foosel/OctoPrint/wiki/Plugin:-Plugin-Manager)
 or manually using this URL:


### PR DESCRIPTION
`libatlas-base-dev` didn't work for me as the readme said it should, but `libopenblas-dev` did.  
Sugested by [@jacopotediosi in #41](https://github.com/AlexVerrico/octoprint-stats/issues/41#issuecomment-1872998842)